### PR TITLE
Fix NullReferenceException in LocationLoading.ToData for unloaded prefabs

### DIFF
--- a/ExpandWorldData/location/LocationLoading.cs
+++ b/ExpandWorldData/location/LocationLoading.cs
@@ -216,18 +216,21 @@ public class LocationLoading
     else
       data.maxAltitude = loc.m_maxAltitude;
     loc.m_prefab.Load();
-    var prefab = loc.m_prefab.Asset.GetComponent<Location>();
-    if (prefab)
+    if (loc.m_prefab.Asset != null)
     {
-      data.randomDamage = prefab.m_applyRandomDamage ? "true" : "";
-      data.exteriorRadius = prefab.m_exteriorRadius;
-      data.clearArea = prefab.m_clearArea;
-      data.discoverLabel = prefab.m_discoverLabel;
-      data.noBuild = prefab.m_noBuild ? "true" : "";
-      if (prefab.m_noBuild && prefab.m_noBuildRadiusOverride > 0f)
-        data.noBuild = prefab.m_noBuildRadiusOverride.ToString(NumberFormatInfo.InvariantInfo);
+      var prefab = loc.m_prefab.Asset.GetComponent<Location>();
+      if (prefab)
+      {
+        data.randomDamage = prefab.m_applyRandomDamage ? "true" : "";
+        data.exteriorRadius = prefab.m_exteriorRadius;
+        data.clearArea = prefab.m_clearArea;
+        data.discoverLabel = prefab.m_discoverLabel;
+        data.noBuild = prefab.m_noBuild ? "true" : "";
+        if (prefab.m_noBuild && prefab.m_noBuildRadiusOverride > 0f)
+          data.noBuild = prefab.m_noBuildRadiusOverride.ToString(NumberFormatInfo.InvariantInfo);
+      }
+      loc.m_prefab.Release();
     }
-    loc.m_prefab.Release();
     return data;
   }
   public static bool IsValid(ZoneSystem.ZoneLocation loc) => loc.m_prefab.IsValid;


### PR DESCRIPTION
## The Problem

When using **ExpandWorldData** alongside **More World Locations AIO** (MWL), a `NullReferenceException` is thrown during world load which prevents the `expand_locations.yaml` file from being written:

```
ExpandWorldData.LocationLoading.ToData (ZoneSystem+ZoneLocation loc)
System.Linq.Enumerable+SelectListIterator`2[TSource,TResult].MoveNext ()
YamlDotNet.Serialization...TraverseList[TContext] (...)
...
ExpandWorldData.LocationLoading.Save (...)
ExpandWorldData.LocationLoading.ToFile ()
ExpandWorldData.LocationLoading.Load ()
ExpandWorldData.LocationLoading.Initialize ()
ExpandWorldData.InitializeContent.Postfix ()
(wrapper dynamic-method) ZoneSystem.DMD<ZoneSystem::Start>(ZoneSystem)
```

### Root cause

Mods like MWL register locations using Jotunn’s soft reference asset system, where prefabs are loaded on demand from individual asset bundles. When EWD serializes zone locations to YAML during ToFile, it calls ToData on each one via a lazy LINQ Select. ToData calls loc.m_prefab.Load() and then immediately accesses loc.m_prefab.Asset.GetComponent<Location>() without a null check. If any location’s asset fails to load for any reason, Asset is null and this throws a NullReferenceException. Because there is no try/catch anywhere in the Save -> ToData pipeline, a single failed asset aborts the entire YAML serialization, preventing expand_locations.yaml from being written.

## The Fix

Added a null check for `loc.m_prefab.Asset` after `Load()`. When the asset is null (failed to load), the prefab-specific fields (`randomDamage`, `exteriorRadius`, `clearArea`, etc.) keep their defaults and the location entry is still serialized with all other fields intact. This lets EWD gracefully handle locations from mods whose assets didn't load, and the `expand_locations.yaml` file is written successfully.

```diff
     loc.m_prefab.Load();
-    var prefab = loc.m_prefab.Asset.GetComponent<Location>();
-    if (prefab)
+    if (loc.m_prefab.Asset != null)
     {
-      data.randomDamage = prefab.m_applyRandomDamage ? "true" : "";
-      ...
+      var prefab = loc.m_prefab.Asset.GetComponent<Location>();
+      if (prefab)
+      {
+        data.randomDamage = prefab.m_applyRandomDamage ? "true" : "";
+        ...
+      }
+      loc.m_prefab.Release();
     }
-    loc.m_prefab.Release();
```

## Steps to reproduce

1. Install Jotunn, ExpandWorldData, and More World Locations AIO
2. Launch the game and load into a world
3. During `ZoneSystem.Start`, EWD's `InitializeContent.Postfix` fires
4. EWD iterates all zone locations to write `expand_locations.yaml` — `ToData` throws a `NullReferenceException` on the location with the null asset, and the file is not written
