### PR TITLE
Fix NullReferenceException on world load when expand_biomes.yaml doesn't exist yet

### DIFF
--- a/ExpandWorldData/world/BiomeManager.cs
+++ b/ExpandWorldData/world/BiomeManager.cs
@@ -117,6 +117,9 @@ public class BiomeManager
   {
     if (Helper.IsClient() || !Configuration.DataBiome) return;
     if (File.Exists(FilePath)) return;
+    // World setup can run before EnvMan exists (fresh install without the yaml file).
+    // Configs get created later at ZoneSystem.Start where EnvMan is guaranteed to exist.
+    if (EnvMan.instance == null) return;
     var biomes = OriginalBiomes.Values.Select(b => EnvMan.instance.m_biomes.Find(ev => ev.m_biome == b)).Where(b => b != null);
     List<BiomeYaml> data = [.. biomes.Select(ToData).ToList(), .. ExtraBiomeYamls.Values];
     var yaml = Yaml.Serializer().Serialize(data);


### PR DESCRIPTION
## Problem

On a fresh install (no `expand_biomes.yaml` yet), hosting or starting a singleplayer world throws a NullReferenceException during world setup and the world hangs on "Generating":

```
NullReferenceException: Object reference not set to an instance of an object
ExpandWorldData.BiomeManager+<>c.<CreateConfigs>b__29_0 (Heightmap+Biome b)
System.Linq.Enumerable...ToList
ExpandWorldData.BiomeManager.CreateConfigs ()
ExpandWorldData.BiomeManager.ReadConfigs ()
ExpandWorldData.InitializeWorld.Postfix ()
(wrapper dynamic-method) WorldGenerator.DMD<WorldGenerator::VersionSetup>(WorldGenerator,int)
WorldGenerator..ctor (World world)
(wrapper dynamic-method) WorldGenerator.DMD<WorldGenerator::Initialize>(World)
(wrapper dynamic-method) ZNet.DMD<ZNet::Awake>(ZNet)
```

Restarting the game usually masks it, because `ZoneSystem.Start` already created the yaml during the failed boot. So this mostly hits the first boot after install (or anyone who deletes the config folder to reset), which makes it look transient and easy to misdiagnose.

## Cause

`InitializeWorld.Postfix` (`WorldGenerator.VersionSetup`, running inside `ZNet.Awake`) calls `BiomeManager.ReadConfigs()`. When the file is missing it falls through to `CreateConfigs()`, which dereferences `EnvMan.instance` — but `EnvMan.Awake` hasn't run yet at that point of `ZNet.Awake`, so `instance` is null.

## Fix

Skip config creation in that early path when `EnvMan` doesn't exist yet. Creation still happens at `ZoneSystem.Start` (`InitializeContent`), where `EnvMan` is guaranteed to exist (all `Awake`s complete before any `Start` runs). No behavior change when the file already exists, which is every install after its first successful boot.

## Testing

All on Valheim Steam build 21981559, EWD 1.68.0:

- Stock 1.68.0, minimal mod set, no `expand_biomes.yaml`: NRE reproduces every boot, world never loads.
- Patched, same setup, brand-new world: generates and loads cleanly, yaml created at `ZoneSystem.Start` with the correct vanilla dump (9 biome entries).
- Patched, larger mod stack (Jotunn, Spawn That, Drop That, Custom Raids, EW Prefabs/Music, WAP), both new-world generation and existing-world load: clean, no log errors.
- Patched, yaml present: guard is never reached, behavior identical to stock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Tzypy37EGsiUadksdSu1p
